### PR TITLE
Update to follow WCAG consensus on rounding

### DIFF
--- a/Color Contrast Analyser.sketchplugin/Contents/Sketch/analyscolor.cocoascript
+++ b/Color Contrast Analyser.sketchplugin/Contents/Sketch/analyscolor.cocoascript
@@ -139,7 +139,7 @@ function getColorContrastOf(color1, color2) {
 
 	// Calculate contrast
 
-	cr = ((L1 + 0.05) / (L2 + 0.05)).toFixed(1);
+	cr = (L1 + 0.05) / (L2 + 0.05);
 
 	return cr;
 }
@@ -164,7 +164,10 @@ function showResult (cr) {
 	if ((fontSize >= 18 || (fontSize >= 14 && isBold)) && cr >=4.5) result = "✅ AAA passed (large text)"
 	if(cr >= 7.0) result = "✅ AAA passed"
 
+	// Floor decimals after first one while avoiding JS floating point errors.
+	var floored = (cr.toString().match(/^-?\d+(?:\.\d{0,1})?/)[0]*1).toFixed(1)
+
 	// Show ratio
-	doc.showMessage(result + " - " + cr + ":1");
+	doc.showMessage(result + " - " + floored + ":1");
 
 }


### PR DESCRIPTION
As described in https://github.com/getflourish/Sketch-Color-Contrast-Analyser/issues/10 the values should not be rounded before comparing. Here I have moved the "rounding" to where it's being done just before showing it to the user. Instead of rounding, I floor the value to 1 decimal. Sadly JavaScript floating point math is tricky, so we have to do it using strings to avoid errors.