### PR TITLE
Resolve "Font sizes not accurate to WCAG guidelines"

### DIFF
--- a/Color Contrast Analyser.sketchplugin/Contents/Sketch/analyscolor.cocoascript
+++ b/Color Contrast Analyser.sketchplugin/Contents/Sketch/analyscolor.cocoascript
@@ -144,6 +144,12 @@ function getColorContrastOf(color1, color2) {
 	return cr;
 }
 
+function convertWcagPointsToNsFontPoints(points) {
+	// WCAG uses CSS points at 96 ppi, 1pt = ~1.3334px
+	// Sketch uses NSFont points at 72 ppi, 1pt = 1px
+	return (points * 96) / 72;
+}
+
 function showResult (cr) {
 	// Check against AA / AAA
 	var result = "❌ AA Failed";
@@ -158,10 +164,14 @@ function showResult (cr) {
 			var isBold = true;
 		}
 	}
-	if ((fontSize >= 18 || (fontSize >= 14 && isBold)) && cr >=3) result = "✅ AA passed (large text)"
+
+	var largeTextRegular = convertWcagPointsToNsFontPoints(18);
+	var largeTextBold = convertWcagPointsToNsFontPoints(14);
+
+	if ((fontSize >= largeTextRegular || (isBold && fontSize >= largeTextBold)) && cr >=3) result = "✅ AA passed (large text)"
 	if(cr >= 4.5) result = "✅ AA passed"
 
-	if ((fontSize >= 18 || (fontSize >= 14 && isBold)) && cr >=4.5) result = "✅ AAA passed (large text)"
+	if ((fontSize >= largeTextRegular || (isBold && fontSize >= largeTextBold)) && cr >=4.5) result = "✅ AAA passed (large text)"
 	if(cr >= 7.0) result = "✅ AAA passed"
 
 	// Floor decimals after first one while avoiding JS floating point errors.

--- a/Color Contrast Analyser.sketchplugin/Contents/Sketch/manifest.json
+++ b/Color Contrast Analyser.sketchplugin/Contents/Sketch/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" : "Color Contrast Analyser",
   "identifier" : "com.getflourish.sketch.colorcontrastanalyser",
-  "version" : "1.1",
+  "version" : "2.0",
   "description" : "A plugin that calculates the color contrast of two layers and evaluates it against the WCAG.",
   "author" : "Florian Schulz", 
   "compatibleVersion": 4,


### PR DESCRIPTION
With reference to #6.

WCAG 2 defines large text as 18 point or 14 point bold using the CSS `pt` size, with a ratio of 1pt = ~1.333px. 

Sketch uses native NSFont to display text at 72 ppi, with a ratio of 1pt = 1px. 

To compare Sketch font sizes with WCAG large text sizes, convert WCAG point size to equivalent Sketch font size in NSFont points.

